### PR TITLE
ngrok public URLs use ngrok.io domain

### DIFF
--- a/content/webhooks/configuring/index.md
+++ b/content/webhooks/configuring/index.md
@@ -29,10 +29,10 @@ When you're done with that, you can expose your localhost by running `./ngrok ht
 on the command line. You should see a line that looks something like this:
 
     #!bash
-    Forwarding    http://7e9ea9dc.ngrok.com -> 127.0.0.1:4567
+    Forwarding    http://7e9ea9dc.ngrok.io -> 127.0.0.1:4567
 
-Copy that funky `*.ngrok.com` URL! We're now going to go *back* to the Payload
-URL and pasting this server into that field. It should look something like `http://7e9ea9dc.ngrok.com/payload`.
+Copy that funky `*.ngrok.io` URL! We're now going to go *back* to the Payload
+URL and pasting this server into that field. It should look something like `http://7e9ea9dc.ngrok.io/payload`.
 
 By doing this, we've set ourselves up to expose our localhost at path `/payload`
 to the Internet.


### PR DESCRIPTION
Although the ngrok site is hosted at https://ngrok.com/ the public socket URLs it creates are of the format: `*.ngrok.io` rather than `*.ngrok.com`
